### PR TITLE
モバイル版のサイドバーエディタ

### DIFF
--- a/src/theme/DocSidebar/Mobile/index.tsx
+++ b/src/theme/DocSidebar/Mobile/index.tsx
@@ -6,6 +6,8 @@ import {
 } from '@docusaurus/theme-common';
 import {useNavbarMobileSidebar} from '@docusaurus/theme-common/internal';
 import DocSidebarItems from '@theme/DocSidebarItems';
+import EditableSidebar from '@theme/DocSidebar/Desktop/EditableSidebar';
+import { useIsEditing } from '@site/src/contexts/EditStateContext';
 
 interface DocSidebarMobileSecondaryMenuProps {
   sidebar: any;
@@ -14,7 +16,16 @@ interface DocSidebarMobileSecondaryMenuProps {
 
 const DocSidebarMobileSecondaryMenu = ({sidebar, path}: DocSidebarMobileSecondaryMenuProps) => {
   const mobileSidebar = useNavbarMobileSidebar();
-  
+  const isEditMode = useIsEditing();
+
+  if (isEditMode) {
+    return (
+      <div className={clsx(ThemeClassNames.docs.docSidebarMenu)}>
+        <EditableSidebar items={sidebar} path={path} />
+      </div>
+    );
+  }
+
   return (
     <ul className={clsx(ThemeClassNames.docs.docSidebarMenu, 'menu__list')}>
       <DocSidebarItems


### PR DESCRIPTION
- Mobile also shows the editable sidebar during edit mode.
- Swapped the mobile sidebar rendering to use `EditableSidebar` when `useIsEditing()` is true.

**Files Updated**
- `src/theme/DocSidebar/Mobile/index.tsx`: Conditionally renders `EditableSidebar` when editing; falls back to normal `DocSidebarItems` otherwise.

**Behavior**
- Desktop: unchanged — already uses `EditableSidebar` in edit mode.
- Mobile: when editing is active, the sidebar becomes the same editable file tree (with add/delete/move, change panel).

**Notes**
- Drag-and-drop uses HTML5 backend; touch DnD may be limited on some mobile devices. If needed, I can add a touch backend or adapt interactions for mobile.
- Want me to run `yarn typecheck` and verify build locally?