### PR TITLE
ディレクトリはドラッグできないように

### DIFF
--- a/src/theme/DocSidebar/Desktop/EditableSidebar/components/FileTreeNode.tsx
+++ b/src/theme/DocSidebar/Desktop/EditableSidebar/components/FileTreeNode.tsx
@@ -70,6 +70,8 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
     collect: (monitor) => ({
       isDragging: monitor.isDragging(),
     }),
+    // Disable dragging for directories
+    canDrag: () => node.type !== 'dir',
   }), [node.path, node.type, selected, selectedPaths]);
   
   // Setup drop (only for directories)
@@ -100,9 +102,9 @@ export const FileTreeNode: React.FC<FileTreeNodeProps> = ({
     const isMultiSelect = e.ctrlKey || e.metaKey;
     onToggleSelection(node.path, isMultiSelect);
   };
-  // Combine drag and drop refs for directories
+  // Combine refs: directories are drop-only (no drag), files are drag-only
   if (node.type === 'dir') {
-    drag(drop(ref));
+    drop(ref);
   } else {
     drag(ref);
   }


### PR DESCRIPTION
- Disabled dragging for directories in the EditableSidebar.
- Directories remain valid drop targets (so you can drop files into them), but you can’t drag a directory itself.

**Key Update**
- File: `src/theme/DocSidebar/Desktop/EditableSidebar/components/FileTreeNode.tsx`
  - Added `canDrag: () => node.type !== 'dir'` to `useDrag`.
  - Changed ref wiring so directories use `drop(ref)` only (no `drag()`), while files use `drag(ref)`.

**Behavior**
- Files: draggable and can be dropped into directories.
- Directories: not draggable; still accept drops.
- No directory move occurs via drag-and-drop, aligning with “block directory drag” requirement.

Would you like me to also filter multi-select drag payloads to exclude directories explicitly? This isn��t necessary for blocking directory moves, but it can make the drag data cleaner.